### PR TITLE
refactor: modularize profile edit page

### DIFF
--- a/app/profile/edit/TermCards.tsx
+++ b/app/profile/edit/TermCards.tsx
@@ -1,0 +1,84 @@
+// app/profile/edit/TermCards.tsx
+
+import { DraggableTermCard } from "@/components/DraggableTermCard";
+import { EditableTermCard } from "@/components/EditableTermCard";
+import {
+  IMMUTABLE_MASTER_PROGRAM_TERMS,
+  MASTER_PROGRAM_TERMS,
+  type MasterProgramTerm,
+} from "@/lib/profile-constants";
+import type { StudentProfile } from "@/types/profile";
+
+interface TermCardsProps {
+  currentProfile: StudentProfile;
+  isMobile: boolean;
+  showBlockTimeline: boolean;
+  onClearTerm: (term: MasterProgramTerm) => Promise<void>;
+  onMoveCourse: (
+    courseId: string,
+    fromTerm: MasterProgramTerm,
+    toTerm: MasterProgramTerm
+  ) => Promise<void>;
+  onRemoveCourse: (courseId: string) => Promise<void>;
+}
+
+export function TermCards({
+  currentProfile,
+  isMobile,
+  onClearTerm,
+  onMoveCourse,
+  onRemoveCourse,
+  showBlockTimeline,
+}: TermCardsProps) {
+  const handleClearTerm = (term: MasterProgramTerm) => {
+    void onClearTerm(term);
+  };
+
+  const handleMoveCourse = (
+    courseId: string,
+    fromTerm: MasterProgramTerm,
+    toTerm: MasterProgramTerm
+  ) => {
+    void onMoveCourse(courseId, fromTerm, toTerm);
+  };
+
+  const handleRemoveCourse = (courseId: string) => {
+    void onRemoveCourse(courseId);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {MASTER_PROGRAM_TERMS.map((term) => {
+        const courses = currentProfile.terms[term];
+        const isImmutable = IMMUTABLE_MASTER_PROGRAM_TERMS.includes(term);
+
+        if (isMobile) {
+          return (
+            <EditableTermCard
+              key={term}
+              courses={courses}
+              onClearTerm={handleClearTerm}
+              onMoveCourse={isImmutable ? undefined : handleMoveCourse}
+              onRemoveCourse={handleRemoveCourse}
+              showBlockTimeline={showBlockTimeline}
+              termNumber={term}
+            />
+          );
+        }
+
+        return (
+          <DraggableTermCard
+            key={term}
+            courses={courses}
+            isDragDisabled={isImmutable}
+            onClearTerm={handleClearTerm}
+            onMoveCourse={isImmutable ? undefined : handleMoveCourse}
+            onRemoveCourse={handleRemoveCourse}
+            showBlockTimeline={showBlockTimeline}
+            termNumber={term}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -2,117 +2,32 @@
 
 "use client";
 
-import { DragDropContext, type DropResult } from "@hello-pangea/dnd";
-import React, { useEffect, useState } from "react";
-import { DraggableTermCard } from "@/components/DraggableTermCard";
-import { EditableTermCard } from "@/components/EditableTermCard";
+import { DragDropContext } from "@hello-pangea/dnd";
+import React, { useState } from "react";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { ProfileSkeletonLoader } from "@/components/ProfileSkeletonLoader";
 import { ProfileStatsCard } from "@/components/ProfileStatsCard";
-import {
-  ProfileProvider,
-  useProfile,
-} from "@/components/profile/ProfileContext";
-import {
-  IMMUTABLE_MASTER_PROGRAM_TERMS,
-  MASTER_PROGRAM_TERMS,
-  type MasterProgramTerm,
-} from "@/lib/profile-constants";
+import { ProfileProvider, useProfile } from "@/components/profile/ProfileContext";
+import { TermCards } from "./TermCards";
+import { useMobileBreakpoint } from "./useMobileBreakpoint";
+import { useProfileDragHandler } from "./useProfileDragHandler";
 
 function ProfileEditPageContent() {
   const { state, removeCourse, moveCourse, clearTerm } = useProfile();
-  const [isMobile, setIsMobile] = useState(false);
   const [showBlockTimeline, setShowBlockTimeline] = useState(true);
-
-  // Detect if we're on mobile/tablet to disable drag and drop
-  useEffect(() => {
-    const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 1024); // Disable on screens smaller than desktop
-    };
-
-    checkIsMobile();
-    window.addEventListener("resize", checkIsMobile);
-
-    return () => window.removeEventListener("resize", checkIsMobile);
-  }, []);
-
-  const handleDragEnd = async (result: DropResult) => {
-    const { destination, source, draggableId } = result;
-
-    // If dropped outside a droppable area
-    if (!destination) {
-      return;
-    }
-
-    // If dropped in the same position
-    if (
-      destination.droppableId === source.droppableId &&
-      destination.index === source.index
-    ) {
-      return;
-    }
-
-    // Extract course ID from draggableId (format: courseId-termX-periodY)
-    const courseId = draggableId.split("-term")[0];
-
-    // Extract term numbers from droppable IDs (now just term-X format)
-    const sourceTermMatch = source.droppableId.match(
-      /term-(\d+)(?:-period-\d+)?$/
-    );
-    const destTermMatch = destination.droppableId.match(
-      /term-(\d+)(?:-period-\d+)?$/
-    );
-
-    if (!(sourceTermMatch && destTermMatch)) {
-      return;
-    }
-
-    const parseTerm = (
-      match: RegExpMatchArray | null
-    ): MasterProgramTerm | null => {
-      if (!match) {
-        return null;
-      }
-
-      const parsed = Number.parseInt(match[1], 10);
-      return (
-        MASTER_PROGRAM_TERMS.find((term) => term === parsed) ?? null
-      );
-    };
-
-    const sourceTerm = parseTerm(sourceTermMatch);
-    const destTerm = parseTerm(destTermMatch);
-
-    if (!(sourceTerm && destTerm)) {
-      return;
-    }
-
-    // Only allow moving between terms 7 and 9 (not 8)
-    if (
-      IMMUTABLE_MASTER_PROGRAM_TERMS.includes(sourceTerm) ||
-      IMMUTABLE_MASTER_PROGRAM_TERMS.includes(destTerm)
-    ) {
-      return;
-    }
-
-    // Only allow moving between different terms
-    if (sourceTerm !== destTerm) {
-      try {
-        await moveCourse(courseId, sourceTerm, destTerm);
-      } catch (error) {
-        console.error("Failed to move course:", error);
-        // You could show a toast notification here
-      }
-    }
-  };
-
+  const isMobile = useMobileBreakpoint();
+  const handleDragEnd = useProfileDragHandler(moveCourse);
   const { current_profile: currentProfile } = state;
+
+  const handleToggleBlockTimeline = () => {
+    setShowBlockTimeline((previous) => !previous);
+  };
 
   if (!currentProfile) {
     return (
       <PageLayout
         navbarMode="profile-edit"
-        onToggleBlockTimeline={() => setShowBlockTimeline(!showBlockTimeline)}
+        onToggleBlockTimeline={handleToggleBlockTimeline}
         showBlockTimeline={showBlockTimeline}
       >
         <ProfileSkeletonLoader />
@@ -123,50 +38,21 @@ function ProfileEditPageContent() {
   return (
     <PageLayout
       navbarMode="profile-edit"
-      onToggleBlockTimeline={() => setShowBlockTimeline(!showBlockTimeline)}
+      onToggleBlockTimeline={handleToggleBlockTimeline}
       showBlockTimeline={showBlockTimeline}
     >
       <DragDropContext onDragEnd={handleDragEnd}>
         <div className="min-h-screen bg-background pt-20">
           <div className="container mx-auto px-4 py-8 space-y-8">
-            {/* Profile Statistics Card */}
             <ProfileStatsCard profile={currentProfile} />
-
-            {/* Term Cards (Draggable on Desktop) */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              {isMobile
-                ? MASTER_PROGRAM_TERMS.map((term) => {
-                    const isImmutable =
-                      IMMUTABLE_MASTER_PROGRAM_TERMS.includes(term);
-                    return (
-                      <EditableTermCard
-                        key={term}
-                        courses={currentProfile.terms[term]}
-                        onClearTerm={clearTerm}
-                        onMoveCourse={isImmutable ? undefined : moveCourse}
-                        onRemoveCourse={removeCourse}
-                        showBlockTimeline={showBlockTimeline}
-                        termNumber={term}
-                      />
-                    );
-                  })
-                : MASTER_PROGRAM_TERMS.map((term) => {
-                    const isImmutable =
-                      IMMUTABLE_MASTER_PROGRAM_TERMS.includes(term);
-                    return (
-                      <DraggableTermCard
-                        key={term}
-                        courses={currentProfile.terms[term]}
-                        isDragDisabled={isImmutable}
-                        onClearTerm={clearTerm}
-                        onMoveCourse={isImmutable ? undefined : moveCourse}
-                        onRemoveCourse={removeCourse}
-                        showBlockTimeline={showBlockTimeline}
-                        termNumber={term}
-                      />
-                    );
-                  })}
-            </div>
+            <TermCards
+              currentProfile={currentProfile}
+              isMobile={isMobile}
+              onClearTerm={clearTerm}
+              onMoveCourse={moveCourse}
+              onRemoveCourse={removeCourse}
+              showBlockTimeline={showBlockTimeline}
+            />
           </div>
         </div>
       </DragDropContext>

--- a/app/profile/edit/useMobileBreakpoint.ts
+++ b/app/profile/edit/useMobileBreakpoint.ts
@@ -1,0 +1,22 @@
+// app/profile/edit/useMobileBreakpoint.ts
+
+import { useEffect, useState } from "react";
+
+const DEFAULT_BREAKPOINT = 1024;
+
+export function useMobileBreakpoint(breakpoint = DEFAULT_BREAKPOINT) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const updateIsMobile = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+
+    updateIsMobile();
+    window.addEventListener("resize", updateIsMobile);
+
+    return () => window.removeEventListener("resize", updateIsMobile);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/app/profile/edit/useProfileDragHandler.ts
+++ b/app/profile/edit/useProfileDragHandler.ts
@@ -1,0 +1,72 @@
+// app/profile/edit/useProfileDragHandler.ts
+
+import { type DropResult } from "@hello-pangea/dnd";
+import { useCallback } from "react";
+import {
+  IMMUTABLE_MASTER_PROGRAM_TERMS,
+  MASTER_PROGRAM_TERMS,
+  type MasterProgramTerm,
+} from "@/lib/profile-constants";
+
+const TERM_ID_PATTERN = /term-(\d+)(?:-period-\d+)?$/;
+
+const parseTermFromMatch = (
+  match: RegExpMatchArray | null
+): MasterProgramTerm | null => {
+  if (!match) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(match[1], 10);
+  return MASTER_PROGRAM_TERMS.find((term) => term === parsed) ?? null;
+};
+
+export function useProfileDragHandler(
+  moveCourse: (
+    courseId: string,
+    fromTerm: MasterProgramTerm,
+    toTerm: MasterProgramTerm
+  ) => Promise<void>
+) {
+  return useCallback(
+    async ({ destination, source, draggableId }: DropResult) => {
+      if (!destination) {
+        return;
+      }
+
+      if (
+        destination.droppableId === source.droppableId &&
+        destination.index === source.index
+      ) {
+        return;
+      }
+
+      const courseId = draggableId.split("-term")[0];
+
+      const sourceTerm = parseTermFromMatch(source.droppableId.match(TERM_ID_PATTERN));
+      const destTerm = parseTermFromMatch(
+        destination.droppableId.match(TERM_ID_PATTERN)
+      );
+
+      if (!(sourceTerm && destTerm)) {
+        return;
+      }
+
+      if (
+        IMMUTABLE_MASTER_PROGRAM_TERMS.includes(sourceTerm) ||
+        IMMUTABLE_MASTER_PROGRAM_TERMS.includes(destTerm)
+      ) {
+        return;
+      }
+
+      if (sourceTerm !== destTerm) {
+        try {
+          await moveCourse(courseId, sourceTerm, destTerm);
+        } catch (error) {
+          console.error("Failed to move course:", error);
+        }
+      }
+    },
+    [moveCourse]
+  );
+}


### PR DESCRIPTION
## Summary
- extract a reusable mobile breakpoint hook for the profile edit page
- encapsulate drag-and-drop handling and term card rendering outside of the route component to reduce file size

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d961a94cd88323998db6dc0195a6a3