### PR TITLE
refactor: simplify course page state management

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { TopControlsSkeleton } from "@/components/course/ControlsSkeleton";
+import { useMemo, useState } from "react";
 import { CourseGridSkeleton } from "@/components/course/CourseCardSkeleton";
 import { CourseGrid } from "@/components/course/CourseGrid";
 import { CourseList } from "@/components/course/CourseList";
@@ -10,6 +9,7 @@ import {
   type FilterState,
 } from "@/components/course/FilterPanel";
 import { FilterSidebarSkeleton } from "@/components/course/FilterSidebarSkeleton";
+import { TopControlsSkeleton } from "@/components/course/ControlsSkeleton";
 import { type ViewMode, ViewToggle } from "@/components/course/ViewToggle";
 import { InfoBanner } from "@/components/InfoBanner";
 import { PageLayout } from "@/components/layout/PageLayout";
@@ -20,269 +20,59 @@ import {
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar";
 import { ProfileSidebarSkeleton } from "@/components/profile/ProfileSidebarSkeleton";
 import { useCourses } from "@/hooks/useCourses";
+import { usePersistentState } from "@/hooks/usePersistentState";
+import { useResponsiveSidebar } from "@/hooks/useResponsiveSidebar";
+import { useToggle } from "@/hooks/useToggle";
+import {
+  createDefaultFilterState,
+  filterCourses,
+  FILTER_STORAGE_KEY,
+  hasActiveFilters,
+  parseFilterState,
+  parseViewMode,
+  VIEW_MODE_STORAGE_KEY,
+} from "@/lib/courseFiltering";
 
 const COURSES_PER_PAGE = 12;
 
 function HomeContent() {
-  // Fetch courses from Supabase API with caching enabled
   const { courses, loading, error } = useCourses({
-    loadAll: true, // We need all courses for client-side filtering
+    loadAll: true,
     enableCache: true,
   });
 
-  // Access profile context
   const { state } = useProfile();
 
-  // Initialize filter state with localStorage persistence
-  const [filterState, setFilterState] = useState<FilterState>(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const saved = localStorage.getItem("litheplan-filters");
-        if (saved) {
-          const parsed = JSON.parse(saved);
-          // Ensure examination array has default values if empty
-          if (!parsed.examination || parsed.examination.length === 0) {
-            parsed.examination = ["TEN", "LAB", "PROJ", "SEM", "UPG"];
-          }
-          return parsed;
-        }
-      } catch (error) {
-        console.warn("Failed to load filter preferences:", error);
-      }
+  const [filterState, setFilterState] = usePersistentState(
+    FILTER_STORAGE_KEY,
+    createDefaultFilterState,
+    {
+      deserialize: parseFilterState,
     }
+  );
 
-    return {
-      level: [],
-      term: [],
-      period: [],
-      block: [],
-      pace: [],
-      campus: [],
-      examination: ["TEN", "LAB", "PROJ", "SEM", "UPG"], // Pre-select all examination types
-      programs: [],
-      huvudomraden: [],
-      search: "",
-    };
-  });
+  const [viewMode, setViewMode] = usePersistentState<ViewMode>(
+    VIEW_MODE_STORAGE_KEY,
+    () => "grid",
+    {
+      deserialize: parseViewMode,
+      serialize: (value) => value,
+    }
+  );
 
-  // Pagination state
+  const { isOpen: sidebarOpen, toggle: toggleSidebar } = useResponsiveSidebar();
+  const {
+    value: profileSidebarOpen,
+    toggle: toggleProfileSidebar,
+  } = useToggle(false);
+
   const [currentPage, setCurrentPage] = useState(1);
 
-  // View mode state with localStorage persistence
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const saved = localStorage.getItem("litheplan-view-mode");
-        if (saved && (saved === "grid" || saved === "list")) {
-          return saved as ViewMode;
-        }
-      } catch (error) {
-        console.warn("Failed to load view mode preference:", error);
-      }
-    }
-    return "grid";
-  });
+  const filteredCourses = useMemo(
+    () => filterCourses(courses, filterState),
+    [courses, filterState]
+  );
 
-  // Sidebar state - Start open on desktop, closed on mobile/tablet
-  const [sidebarOpen, setSidebarOpen] = useState(false);
-
-  // Save filter state to localStorage whenever it changes
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        localStorage.setItem("litheplan-filters", JSON.stringify(filterState));
-      } catch (error) {
-        console.warn("Failed to save filter preferences:", error);
-      }
-    }
-  }, [filterState]);
-
-  // Save view mode to localStorage whenever it changes
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        localStorage.setItem("litheplan-view-mode", viewMode);
-      } catch (error) {
-        console.warn("Failed to save view mode preference:", error);
-      }
-    }
-  }, [viewMode]);
-
-  // Set initial sidebar state based on screen size
-  useEffect(() => {
-    const handleResize = () => {
-      // Open sidebar for desktop (1024px and above), closed for tablet/mobile
-      setSidebarOpen(window.innerWidth >= 1024);
-    };
-
-    // Set initial state
-    handleResize();
-
-    // Listen for resize events
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-  const [profileSidebarOpen, setProfileSidebarOpen] = useState(false);
-
-  const toggleSidebar = () => {
-    setSidebarOpen(!sidebarOpen);
-  };
-
-  const toggleProfileSidebar = () => {
-    setProfileSidebarOpen(!profileSidebarOpen);
-  };
-
-  // Filter logic function
-  const filteredCourses = useMemo(() => {
-    return courses.filter((course) => {
-      // Enhanced search filter - search across multiple fields:
-      // - Course name and ID (original functionality)
-      // - Examiner (examinator field)
-      // - Director (studierektor field)
-      // - Programs array
-      if (filterState.search.trim()) {
-        const searchTerm = filterState.search.toLowerCase().trim();
-        const matchesName = course.name.toLowerCase().includes(searchTerm);
-        const matchesId = course.id.toLowerCase().includes(searchTerm);
-        const matchesExaminer = course.examinator
-          ?.toLowerCase()
-          .includes(searchTerm);
-        const matchesDirector = course.studierektor
-          ?.toLowerCase()
-          .includes(searchTerm);
-        const matchesPrograms = course.programs.some((program) =>
-          program.toLowerCase().includes(searchTerm)
-        );
-
-        if (
-          !(
-            matchesName ||
-            matchesId ||
-            matchesExaminer ||
-            matchesDirector ||
-            matchesPrograms
-          )
-        ) {
-          return false;
-        }
-      }
-
-      // Level filter
-      if (
-        filterState.level.length > 0 &&
-        !filterState.level.includes(course.level)
-      ) {
-        return false;
-      }
-
-      // Term filter - handle string arrays
-      if (filterState.term.length > 0) {
-        const courseTerms = course.term; // Already an array of strings
-        const termMatches = filterState.term.some((selectedTerm) => {
-          if (selectedTerm === 7) {
-            // Term 7 checkbox should match courses available in term "7" OR "9" (since they're combined)
-            return courseTerms.includes("7") || courseTerms.includes("9");
-          }
-          // Convert selectedTerm to string for comparison
-          return courseTerms.includes(selectedTerm.toString());
-        });
-        if (!termMatches) {
-          return false;
-        }
-      }
-
-      // Period filter - handle string arrays
-      if (filterState.period.length > 0) {
-        const hasMatchingPeriod = filterState.period.some((selectedPeriod) =>
-          course.period.includes(selectedPeriod.toString())
-        );
-        if (!hasMatchingPeriod) {
-          return false;
-        }
-      }
-
-      // Block filter - handle string arrays
-      if (filterState.block.length > 0) {
-        const courseBlocks = course.block; // Already an array of strings
-        const hasMatchingBlock = filterState.block.some((selectedBlock) =>
-          courseBlocks.includes(selectedBlock.toString())
-        );
-        if (!hasMatchingBlock) {
-          return false;
-        }
-      }
-
-      // Pace filter
-      if (
-        filterState.pace.length > 0 &&
-        !filterState.pace.includes(course.pace)
-      ) {
-        return false;
-      }
-
-      // Campus filter
-      if (
-        filterState.campus.length > 0 &&
-        !filterState.campus.includes(course.campus)
-      ) {
-        return false;
-      }
-
-      // Examination filter - exclusion filtering (show courses that don't have unselected examination types)
-      if (filterState.examination.length < 5) {
-        // Only filter if not all examination types are selected
-        const allExaminationTypes = ["TEN", "LAB", "PROJ", "SEM", "UPG"];
-        const unselectedExaminationTypes = allExaminationTypes.filter(
-          (examType) => !filterState.examination.includes(examType)
-        );
-
-        const courseExaminations = course.examination;
-        const hasAnyUnselectedExamination = unselectedExaminationTypes.some(
-          (examType) =>
-            courseExaminations.includes(
-              examType as "TEN" | "LAB" | "PROJ" | "SEM" | "UPG"
-            )
-        );
-
-        if (hasAnyUnselectedExamination) {
-          return false;
-        }
-      }
-
-      // Programs filter - multiple selection, show only courses eligible for selected programs
-      if (filterState.programs.length > 0) {
-        const coursePrograms = course.programs || [];
-        const hasAnySelectedProgram = filterState.programs.some((program) =>
-          coursePrograms.includes(program)
-        );
-        if (!hasAnySelectedProgram) {
-          return false;
-        }
-      }
-
-      // Huvudområden filter - multiple selection, show only courses eligible for selected huvudområden
-      if (filterState.huvudomraden.length > 0) {
-        const courseHuvudomraden = course.huvudomrade || "";
-        const courseHuvudomradenArray = courseHuvudomraden
-          .split(",")
-          .map((h) => h.trim())
-          .filter((h) => h !== "");
-
-        const hasAnySelectedHuvudomrade = filterState.huvudomraden.some(
-          (selectedHuvudomrade) =>
-            courseHuvudomradenArray.includes(selectedHuvudomrade)
-        );
-
-        if (!hasAnySelectedHuvudomrade) {
-          return false;
-        }
-      }
-
-      return true;
-    });
-  }, [courses, filterState]);
-
-  // Pagination logic
   const totalPages = Math.ceil(filteredCourses.length / COURSES_PER_PAGE);
   const paginatedCourses = useMemo(() => {
     const startIndex = (currentPage - 1) * COURSES_PER_PAGE;
@@ -292,37 +82,24 @@ function HomeContent() {
 
   const handleFilterChange = (newFilters: FilterState) => {
     setFilterState(newFilters);
-    setCurrentPage(1); // Reset to first page when filters change
+    setCurrentPage(1);
   };
 
   const handleResetFilters = () => {
-    setFilterState({
-      level: [],
-      term: [],
-      period: [],
-      block: [],
-      pace: [],
-      campus: [],
-      examination: ["TEN", "LAB", "PROJ", "SEM", "UPG"], // Reset to all examination types selected
-      programs: [],
-      huvudomraden: [],
-      search: "",
-    });
-    setCurrentPage(1); // Reset to first page when filters are reset
+    setFilterState(createDefaultFilterState());
+    setCurrentPage(1);
   };
 
   const handleSearchChange = (searchQuery: string) => {
-    setFilterState((prev) => ({ ...prev, search: searchQuery }));
-    setCurrentPage(1); // Reset to first page when search changes
+    setFilterState((previous) => ({ ...previous, search: searchQuery }));
+    setCurrentPage(1);
   };
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
-    // Scroll to top of page
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
-  // Show loading state with skeleton
   if (loading) {
     return (
       <PageLayout
@@ -334,28 +111,23 @@ function HomeContent() {
       >
         <div className="min-h-screen bg-background">
           <div className="flex">
-            {/* Left Filter Sidebar Skeleton - Responsive based on screen size */}
             <FilterSidebarSkeleton
               isOpen={sidebarOpen}
               onToggle={toggleSidebar}
             />
 
-            {/* Right Profile Sidebar Skeleton - Default closed state */}
             <ProfileSidebarSkeleton isOpen={false} onToggle={() => {}} />
 
-            {/* Main Content Area - Match real layout with proper margins */}
             <div
               className={`w-full pt-20 ${
                 sidebarOpen ? "lg:ml-80 xl:ml-96" : "lg:ml-12"
               } lg:mr-12`}
             >
               <div className="container mx-auto px-4 py-8 max-w-7xl">
-                {/* Top Controls - Skeleton with integrated loading indicator */}
                 <TopControlsSkeleton />
 
-                {/* Course Grid Skeleton - Always assume sidebar is open during loading */}
                 <CourseGridSkeleton
-                  count={12}
+                  count={COURSES_PER_PAGE}
                   profileSidebarOpen={false}
                   sidebarOpen={true}
                 />
@@ -367,7 +139,6 @@ function HomeContent() {
     );
   }
 
-  // Show error state
   if (error) {
     return (
       <PageLayout
@@ -401,9 +172,7 @@ function HomeContent() {
       searchQuery={filterState.search}
     >
       <div className="min-h-screen bg-background">
-        {/* Main Content with Sidebar */}
         <div className="flex">
-          {/* Left Filter Sidebar */}
           <CollapsibleFilterSidebar
             courses={courses}
             filterState={filterState}
@@ -413,23 +182,19 @@ function HomeContent() {
             onToggle={toggleSidebar}
           />
 
-          {/* Right Profile Sidebar */}
           <ProfileSidebar
             isOpen={profileSidebarOpen}
             onToggle={toggleProfileSidebar}
             profile={state.current_profile}
           />
 
-          {/* Main Content Area */}
           <div
             className={`w-full transition-all duration-300 ease-in-out pt-20 ${
               sidebarOpen ? "lg:ml-80 xl:ml-96" : "lg:ml-12"
             } ${profileSidebarOpen ? "lg:mr-80 xl:mr-96" : "lg:mr-12"}`}
           >
             <div className="container mx-auto px-4 py-8 max-w-7xl">
-              {/* Info Banner */}
               <InfoBanner />
-              {/* View Toggle Controls */}
               <div className="w-full max-w-full mb-6 px-1 sm:px-2 lg:px-0">
                 <div className="flex justify-end items-center">
                   <ViewToggle
@@ -439,17 +204,11 @@ function HomeContent() {
                 </div>
               </div>
 
-              {/* Course Catalog View */}
               {viewMode === "grid" ? (
                 <CourseGrid
                   courses={paginatedCourses}
                   currentPage={currentPage}
-                  isFiltered={Object.entries(filterState).some(
-                    ([key, value]) =>
-                      key === "programs" || key === "search"
-                        ? value
-                        : (value as (string | number)[]).length > 0
-                  )}
+                  isFiltered={hasActiveFilters(filterState)}
                   itemsPerPage={COURSES_PER_PAGE}
                   onPageChange={handlePageChange}
                   profileSidebarOpen={profileSidebarOpen}
@@ -462,12 +221,7 @@ function HomeContent() {
                   activeFilters={filterState}
                   courses={paginatedCourses}
                   currentPage={currentPage}
-                  isFiltered={Object.entries(filterState).some(
-                    ([key, value]) =>
-                      key === "programs" || key === "search"
-                        ? value
-                        : (value as (string | number)[]).length > 0
-                  )}
+                  isFiltered={hasActiveFilters(filterState)}
                   itemsPerPage={COURSES_PER_PAGE}
                   onPageChange={handlePageChange}
                   totalCourses={filteredCourses.length}

--- a/hooks/usePersistentState.ts
+++ b/hooks/usePersistentState.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+
+export type Serializer<T> = (value: T) => string;
+export type Deserializer<T> = (value: string) => T | null;
+
+type PersistentStateOptions<T> = {
+  serialize?: Serializer<T>;
+  deserialize?: Deserializer<T>;
+  onLoadError?: (error: unknown) => void;
+  onSaveError?: (error: unknown) => void;
+};
+
+const defaultSerialize = <T,>(value: T) => JSON.stringify(value);
+const defaultDeserialize = <T,>(value: string) => JSON.parse(value) as T;
+
+const createLogger = (action: "load" | "save", key: string) => (error: unknown) => {
+  console.warn(`Failed to ${action} persisted state for "${key}"`, error);
+};
+
+export function usePersistentState<T>(
+  key: string,
+  getDefaultValue: () => T,
+  options: PersistentStateOptions<T> = {}
+) {
+  const serializeOption = options.serialize ?? defaultSerialize<T>;
+  const deserializeOption = options.deserialize ?? defaultDeserialize<T>;
+  const onLoadErrorOption = options.onLoadError ?? createLogger("load", key);
+  const onSaveErrorOption = options.onSaveError ?? createLogger("save", key);
+
+  const serializeRef = useRef(serializeOption);
+  const onSaveErrorRef = useRef(onSaveErrorOption);
+
+  useEffect(() => {
+    serializeRef.current = serializeOption;
+    onSaveErrorRef.current = onSaveErrorOption;
+  }, [serializeOption, onSaveErrorOption]);
+
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") {
+      return getDefaultValue();
+    }
+
+    try {
+      const stored = window.localStorage.getItem(key);
+      if (!stored) {
+        return getDefaultValue();
+      }
+
+      const parsed = deserializeOption(stored);
+      return parsed ?? getDefaultValue();
+    } catch (error) {
+      onLoadErrorOption(error);
+      return getDefaultValue();
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const serialized = serializeRef.current(state);
+      window.localStorage.setItem(key, serialized);
+    } catch (error) {
+      onSaveErrorRef.current(error);
+    }
+  }, [key, state]);
+
+  return [state, setState] as const;
+}

--- a/hooks/useResponsiveSidebar.ts
+++ b/hooks/useResponsiveSidebar.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from "react";
+
+const DEFAULT_BREAKPOINT = 1024;
+
+export function useResponsiveSidebar(breakpoint: number = DEFAULT_BREAKPOINT) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const updateState = () => {
+      setIsOpen(window.innerWidth >= breakpoint);
+    };
+
+    updateState();
+    window.addEventListener("resize", updateState);
+
+    return () => {
+      window.removeEventListener("resize", updateState);
+    };
+  }, [breakpoint]);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return { isOpen, toggle };
+}

--- a/hooks/useToggle.ts
+++ b/hooks/useToggle.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from "react";
+
+export function useToggle(initialState = false) {
+  const [value, setValue] = useState(initialState);
+
+  const toggle = useCallback(() => {
+    setValue((previous) => !previous);
+  }, []);
+
+  return { value, toggle, setValue } as const;
+}

--- a/lib/courseFiltering.ts
+++ b/lib/courseFiltering.ts
@@ -1,0 +1,220 @@
+import type { FilterState } from "@/components/course/FilterPanel";
+import type { ViewMode } from "@/components/course/ViewToggle";
+import type { Course } from "@/types/course";
+
+export const FILTER_STORAGE_KEY = "litheplan-filters";
+export const VIEW_MODE_STORAGE_KEY = "litheplan-view-mode";
+
+const EXAMINATION_TYPES = ["TEN", "LAB", "PROJ", "SEM", "UPG"] as const;
+
+export function createDefaultFilterState(): FilterState {
+  return {
+    level: [],
+    term: [],
+    period: [],
+    block: [],
+    pace: [],
+    campus: [],
+    examination: [...EXAMINATION_TYPES],
+    programs: [],
+    huvudomraden: [],
+    search: "",
+  };
+}
+
+export function parseFilterState(serialized: string): FilterState | null {
+  try {
+    const parsed = JSON.parse(serialized) as Partial<FilterState> | null;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+
+    const next: FilterState = {
+      ...createDefaultFilterState(),
+      ...parsed,
+    };
+
+    if (!next.examination?.length) {
+      next.examination = [...EXAMINATION_TYPES];
+    }
+
+    return next;
+  } catch (error) {
+    console.warn("Failed to parse filter preferences", error);
+    return null;
+  }
+}
+
+export function parseViewMode(value: string): ViewMode | null {
+  return value === "grid" || value === "list" ? value : null;
+}
+
+const matchesSearch = (course: Course, searchTerm: string) => {
+  const normalizedTerm = searchTerm.toLowerCase().trim();
+  if (!normalizedTerm) {
+    return true;
+  }
+
+  const matchesName = course.name.toLowerCase().includes(normalizedTerm);
+  const matchesId = course.id.toLowerCase().includes(normalizedTerm);
+  const matchesExaminer = course.examinator
+    ?.toLowerCase()
+    .includes(normalizedTerm);
+  const matchesDirector = course.studierektor
+    ?.toLowerCase()
+    .includes(normalizedTerm);
+  const matchesPrograms = course.programs.some((program) =>
+    program.toLowerCase().includes(normalizedTerm)
+  );
+
+  return (
+    matchesName ||
+    matchesId ||
+    Boolean(matchesExaminer) ||
+    Boolean(matchesDirector) ||
+    matchesPrograms
+  );
+};
+
+const matchesTerm = (course: Course, selectedTerms: FilterState["term"]) => {
+  if (selectedTerms.length === 0) {
+    return true;
+  }
+
+  return selectedTerms.some((selectedTerm) => {
+    if (selectedTerm === 7) {
+      return course.term.includes("7") || course.term.includes("9");
+    }
+
+    return course.term.includes(selectedTerm.toString());
+  });
+};
+
+const matchesPeriod = (
+  course: Course,
+  selectedPeriods: FilterState["period"]
+) => {
+  if (selectedPeriods.length === 0) {
+    return true;
+  }
+
+  return selectedPeriods.some((period) =>
+    course.period.includes(period.toString())
+  );
+};
+
+const matchesBlock = (course: Course, selectedBlocks: FilterState["block"]) => {
+  if (selectedBlocks.length === 0) {
+    return true;
+  }
+
+  return selectedBlocks.some((block) =>
+    course.block.includes(block.toString())
+  );
+};
+
+const matchesSimpleArray = (
+  selectedValues: string[],
+  value: string
+) => selectedValues.length === 0 || selectedValues.includes(value);
+
+const matchesExamination = (
+  course: Course,
+  selectedExaminations: FilterState["examination"]
+) => {
+  if (selectedExaminations.length === EXAMINATION_TYPES.length) {
+    return true;
+  }
+
+  const unselected = EXAMINATION_TYPES.filter(
+    (exam) => !selectedExaminations.includes(exam)
+  );
+
+  return !unselected.some((exam) => course.examination.includes(exam));
+};
+
+const matchesPrograms = (
+  coursePrograms: string[],
+  selectedPrograms: FilterState["programs"]
+) => {
+  if (selectedPrograms.length === 0) {
+    return true;
+  }
+
+  return selectedPrograms.some((program) => coursePrograms.includes(program));
+};
+
+const matchesHuvudomraden = (
+  course: Course,
+  selectedHuvudomraden: FilterState["huvudomraden"]
+) => {
+  if (selectedHuvudomraden.length === 0) {
+    return true;
+  }
+
+  const courseHuvudomraden = (course.huvudomrade ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return selectedHuvudomraden.some((huvudomrade) =>
+    courseHuvudomraden.includes(huvudomrade)
+  );
+};
+
+export function filterCourses(
+  courses: Course[],
+  filterState: FilterState
+): Course[] {
+  return courses.filter((course) => {
+    if (!matchesSearch(course, filterState.search)) {
+      return false;
+    }
+
+    if (!matchesSimpleArray(filterState.level, course.level)) {
+      return false;
+    }
+
+    if (!matchesTerm(course, filterState.term)) {
+      return false;
+    }
+
+    if (!matchesPeriod(course, filterState.period)) {
+      return false;
+    }
+
+    if (!matchesBlock(course, filterState.block)) {
+      return false;
+    }
+
+    if (!matchesSimpleArray(filterState.pace, course.pace)) {
+      return false;
+    }
+
+    if (!matchesSimpleArray(filterState.campus, course.campus)) {
+      return false;
+    }
+
+    if (!matchesExamination(course, filterState.examination)) {
+      return false;
+    }
+
+    if (!matchesPrograms(course.programs ?? [], filterState.programs)) {
+      return false;
+    }
+
+    if (!matchesHuvudomraden(course, filterState.huvudomraden)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+export function hasActiveFilters(filterState: FilterState) {
+  return Object.entries(filterState).some(([key, value]) =>
+    key === "programs" || key === "search"
+      ? Boolean(value)
+      : (value as (string | number)[]).length > 0
+  );
+}


### PR DESCRIPTION
## Summary
- extract reusable persistent state and responsive sidebar hooks to simplify the home page component
- centralize course filtering helpers and default filter state handling in `lib/courseFiltering`
- refactor `app/page.tsx` to rely on the new utilities, keeping the rendered UI unchanged while shrinking the file

## Testing
- npm run lint *(fails: existing lint violations in api routes and Supabase middleware)*

------
https://chatgpt.com/codex/tasks/task_e_68d9618a2a348323a6905ca127ba5471