### PR TITLE
Refactor magic numbers flagged by lint

### DIFF
--- a/app/profile/edit/page.tsx
+++ b/app/profile/edit/page.tsx
@@ -19,6 +19,8 @@ import {
   type MasterProgramTerm,
 } from "@/lib/profile-constants";
 
+const DESKTOP_BREAKPOINT_PX = 1024;
+
 function ProfileEditPageContent() {
   const { state, removeCourse, moveCourse, clearTerm } = useProfile();
   const [isMobile, setIsMobile] = useState(false);
@@ -27,7 +29,7 @@ function ProfileEditPageContent() {
   // Detect if we're on mobile/tablet to disable drag and drop
   useEffect(() => {
     const checkIsMobile = () => {
-      setIsMobile(window.innerWidth < 1024); // Disable on screens smaller than desktop
+      setIsMobile(window.innerWidth < DESKTOP_BREAKPOINT_PX); // Disable on screens smaller than desktop
     };
 
     checkIsMobile();

--- a/components/EditableTermCard.tsx
+++ b/components/EditableTermCard.tsx
@@ -9,8 +9,37 @@ import {
   getConflictBorderClass,
 } from "@/lib/conflict-utils";
 import { getLevelColor } from "@/lib/course-utils";
-import { type MasterProgramTerm } from "@/lib/profile-constants";
+import {
+  MASTER_PROGRAM_TERM_EIGHT,
+  MASTER_PROGRAM_TERM_NINE,
+  MASTER_PROGRAM_TERM_SEVEN,
+  type MasterProgramTerm,
+} from "@/lib/profile-constants";
 import type { Course } from "@/types/course";
+
+const BLOCK_NUMBER_FIRST = 1;
+const BLOCK_NUMBER_SECOND = 2;
+const BLOCK_NUMBER_THIRD = 3;
+const BLOCK_NUMBER_FOURTH = 4;
+const BLOCK_NUMBERS = [
+  BLOCK_NUMBER_FIRST,
+  BLOCK_NUMBER_SECOND,
+  BLOCK_NUMBER_THIRD,
+  BLOCK_NUMBER_FOURTH,
+] as const;
+type BlockNumber = (typeof BLOCK_NUMBERS)[number];
+const DEFAULT_BLOCK_BADGE_COLOR =
+  "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
+const BLOCK_BADGE_COLORS: Record<BlockNumber, string> = {
+  [BLOCK_NUMBER_FIRST]:
+    "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+  [BLOCK_NUMBER_SECOND]:
+    "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  [BLOCK_NUMBER_THIRD]:
+    "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  [BLOCK_NUMBER_FOURTH]:
+    "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
+};
 
 interface EditableTermCardProps {
   termNumber: MasterProgramTerm;
@@ -55,20 +84,8 @@ export function EditableTermCard({
     ),
   };
 
-  const getBlockBadgeColor = (blockNum: number) => {
-    switch (blockNum) {
-      case 1:
-        return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
-      case 2:
-        return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
-      case 3:
-        return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200";
-      case 4:
-        return "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200";
-      default:
-        return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
-    }
-  };
+  const getBlockBadgeColor = (blockNum: number) =>
+    BLOCK_BADGE_COLORS[blockNum as BlockNumber] ?? DEFAULT_BLOCK_BADGE_COLOR;
 
   const renderBlockIndicators = (course: Course, currentPeriod: 1 | 2) => {
     const is50Percent = course.pace === "50%";
@@ -112,9 +129,15 @@ export function EditableTermCard({
     currentPeriod: 1 | 2
   ) => {
     // Create a visual timeline showing which blocks are occupied for this specific period
-    const blockOccupancy: {
-      [key: number]: Array<{ course: Course; is50Percent: boolean }>;
-    } = { 1: [], 2: [], 3: [], 4: [] };
+    const blockOccupancy: Record<
+      BlockNumber,
+      Array<{ course: Course; is50Percent: boolean }>
+    > = {
+      [BLOCK_NUMBER_FIRST]: [],
+      [BLOCK_NUMBER_SECOND]: [],
+      [BLOCK_NUMBER_THIRD]: [],
+      [BLOCK_NUMBER_FOURTH]: [],
+    };
 
     periodCourses.forEach((course) => {
       let blocks: number[];
@@ -143,7 +166,7 @@ export function EditableTermCard({
           Period {currentPeriod} Block Timeline:
         </div>
         <div className="grid grid-cols-4 gap-1">
-          {[1, 2, 3, 4].map((blockNum) => {
+          {BLOCK_NUMBERS.map((blockNum) => {
             const courses =
               blockOccupancy[blockNum as keyof typeof blockOccupancy];
             const hasConflict = courses.length > 1;
@@ -286,12 +309,18 @@ export function EditableTermCard({
           </div>
 
           {/* Transfer buttons - right-aligned, only show for terms 7 and 9, and when onMoveCourse is available */}
-          {onMoveCourse && termNumber !== 8 && (
+          {onMoveCourse && termNumber !== MASTER_PROGRAM_TERM_EIGHT && (
             <div className="flex justify-end gap-1 mt-3 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-              {termNumber === 7 && (
+              {termNumber === MASTER_PROGRAM_TERM_SEVEN && (
                 <Button
                   className="h-6 px-2 text-xs"
-                  onClick={() => onMoveCourse(course.id, 7, 9)}
+                  onClick={() =>
+                    onMoveCourse(
+                      course.id,
+                      MASTER_PROGRAM_TERM_SEVEN,
+                      MASTER_PROGRAM_TERM_NINE
+                    )
+                  }
                   size="sm"
                   title="Move to Term 9"
                   variant="outline"
@@ -300,10 +329,16 @@ export function EditableTermCard({
                   Term 9
                 </Button>
               )}
-              {termNumber === 9 && (
+              {termNumber === MASTER_PROGRAM_TERM_NINE && (
                 <Button
                   className="h-6 px-2 text-xs"
-                  onClick={() => onMoveCourse(course.id, 9, 7)}
+                  onClick={() =>
+                    onMoveCourse(
+                      course.id,
+                      MASTER_PROGRAM_TERM_NINE,
+                      MASTER_PROGRAM_TERM_SEVEN
+                    )
+                  }
                   size="sm"
                   title="Move to Term 7"
                   variant="outline"

--- a/hooks/useCourses.ts
+++ b/hooks/useCourses.ts
@@ -35,7 +35,13 @@ const coursesCache = new Map<
     pagination: UseCoursesResult["pagination"];
   }
 >();
-const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+const CACHE_DURATION_MINUTES = 5;
+const SECONDS_PER_MINUTE = 60;
+const MILLISECONDS_PER_SECOND = 1000;
+const CACHE_DURATION_MS =
+  CACHE_DURATION_MINUTES *
+  SECONDS_PER_MINUTE *
+  MILLISECONDS_PER_SECOND; // 5 minutes
 
 export function useCourses(
   options: {
@@ -65,7 +71,7 @@ export function useCourses(
     // Check cache first
     if (enableCache && coursesCache.has(cacheKey)) {
       const cached = coursesCache.get(cacheKey)!;
-      if (Date.now() - cached.timestamp < CACHE_DURATION) {
+      if (Date.now() - cached.timestamp < CACHE_DURATION_MS) {
         console.log("📦 Using cached courses data");
         setCourses(cached.data);
         setPagination(cached.pagination);

--- a/lib/course-conflict-utils.ts
+++ b/lib/course-conflict-utils.ts
@@ -1,5 +1,6 @@
 // lib/course-conflict-utils.ts
 
+import { MASTER_PROGRAM_TERMS } from "@/lib/profile-constants";
 import type { Course } from "@/types/course";
 import type { StudentProfile } from "@/types/profile";
 
@@ -48,7 +49,7 @@ export function findCourseConflicts(
   }[] = [];
 
   // Check each term in the profile
-  ([7, 8, 9] as const).forEach((term) => {
+  MASTER_PROGRAM_TERMS.forEach((term) => {
     const termCourses = currentProfile.terms[term];
     termCourses.forEach((existingCourse) => {
       // Check if new course conflicts with existing course

--- a/lib/profile-constants.ts
+++ b/lib/profile-constants.ts
@@ -1,6 +1,15 @@
-export const MASTER_PROGRAM_TERMS = [7, 8, 9] as const;
+export const MASTER_PROGRAM_TERM_SEVEN = 7;
+export const MASTER_PROGRAM_TERM_EIGHT = 8;
+export const MASTER_PROGRAM_TERM_NINE = 9;
+export const MASTER_PROGRAM_TERMS = [
+  MASTER_PROGRAM_TERM_SEVEN,
+  MASTER_PROGRAM_TERM_EIGHT,
+  MASTER_PROGRAM_TERM_NINE,
+] as const;
 export type MasterProgramTerm = (typeof MASTER_PROGRAM_TERMS)[number];
-export const IMMUTABLE_MASTER_PROGRAM_TERMS: readonly MasterProgramTerm[] = [8];
+export const IMMUTABLE_MASTER_PROGRAM_TERMS: readonly MasterProgramTerm[] = [
+  MASTER_PROGRAM_TERM_EIGHT,
+];
 
 export const MASTER_PROGRAM_TARGET_CREDITS = 90;
 export const MASTER_PROGRAM_MIN_ADVANCED_CREDITS = 60;

--- a/scripts/fetch-course-stats.js
+++ b/scripts/fetch-course-stats.js
@@ -25,6 +25,8 @@ if (!(supabaseUrl && supabaseKey)) {
 }
 
 const supabase = createClient(supabaseUrl, supabaseKey);
+const CONSOLE_DIVIDER_LENGTH = 50;
+const PERCENTAGE_SCALE = 100;
 
 async function fetchCourseStatistics() {
   console.log("🔍 Fetching course statistics from Supabase...\n");
@@ -148,9 +150,12 @@ function calculateStatistics(courses) {
   return stats;
 }
 
+const formatPercentage = (count, total) =>
+  ((count / total) * PERCENTAGE_SCALE).toFixed(1);
+
 function displayStatistics(stats) {
   console.log("📊 COURSE STATISTICS SUMMARY");
-  console.log("=".repeat(50));
+  console.log("=".repeat(CONSOLE_DIVIDER_LENGTH));
 
   console.log(`\n📚 TOTAL COURSES: ${stats.total}`);
 
@@ -158,7 +163,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byLevel)
     .sort(([, a], [, b]) => b - a)
     .forEach(([level, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${level}: ${count} (${percentage}%)`);
     });
 
@@ -166,7 +171,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byCampus)
     .sort(([, a], [, b]) => b - a)
     .forEach(([campus, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${campus}: ${count} (${percentage}%)`);
     });
 
@@ -174,7 +179,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byCredits)
     .sort(([, a], [, b]) => b - a)
     .forEach(([credits, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${credits}: ${count} (${percentage}%)`);
     });
 
@@ -182,7 +187,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byPace)
     .sort(([, a], [, b]) => b - a)
     .forEach(([pace, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${pace}: ${count} (${percentage}%)`);
     });
 
@@ -190,7 +195,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byTerm)
     .sort(([a], [b]) => a.localeCompare(b))
     .forEach(([term, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${term}: ${count} (${percentage}%)`);
     });
 
@@ -198,7 +203,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byPeriod)
     .sort(([a], [b]) => a.localeCompare(b))
     .forEach(([period, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${period}: ${count} (${percentage}%)`);
     });
 
@@ -206,7 +211,7 @@ function displayStatistics(stats) {
   Object.entries(stats.byBlock)
     .sort(([a], [b]) => a.localeCompare(b))
     .forEach(([block, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${block}: ${count} (${percentage}%)`);
     });
 
@@ -214,17 +219,21 @@ function displayStatistics(stats) {
   Object.entries(stats.byExamination)
     .sort(([, a], [, b]) => b - a)
     .forEach(([exam, count]) => {
-      const percentage = ((count / stats.total) * 100).toFixed(1);
+      const percentage = formatPercentage(count, stats.total);
       console.log(`   ${exam}: ${count} (${percentage}%)`);
     });
 
   console.log("\n📋 NOTES/RESTRICTIONS:");
-  const notesPercentage = ((stats.withNotes / stats.total) * 100).toFixed(1);
+  const notesPercentageValue =
+    (stats.withNotes / stats.total) * PERCENTAGE_SCALE;
+  const notesPercentage = notesPercentageValue.toFixed(1);
   console.log(
     `   Courses with notes: ${stats.withNotes} (${notesPercentage}%)`
   );
   console.log(
-    `   Courses without notes: ${stats.withoutNotes} (${(100 - notesPercentage).toFixed(1)}%)`
+    `   Courses without notes: ${stats.withoutNotes} (${(
+      PERCENTAGE_SCALE - notesPercentageValue
+    ).toFixed(1)}%)`
   );
 
   console.log("\n🎯 PROGRAM COVERAGE:");

--- a/scripts/import-courses.js
+++ b/scripts/import-courses.js
@@ -18,6 +18,7 @@ if (!(supabaseUrl && supabaseKey)) {
 }
 
 const supabase = createClient(supabaseUrl, supabaseKey);
+const RATE_LIMIT_DELAY_MS = 100;
 
 async function importCourses() {
   console.log("Starting course data import...");
@@ -79,7 +80,7 @@ async function importCourses() {
       }
 
       // Small delay to avoid rate limits
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY_MS));
     }
 
     console.log("\nImport Summary:");


### PR DESCRIPTION
## Summary
- replace hard-coded viewport threshold in the profile edit page with a named breakpoint constant
- consolidate block indicators and master-program term numbers behind descriptive constants used across the editor and helpers
- add reusable timing and percentage constants for course hooks and scripts to satisfy no-magic-number lint checks

## Testing
- npm run lint *(fails: pre-existing lint violations unrelated to magic-number cleanup)*

------
https://chatgpt.com/codex/tasks/task_e_68d961faf914832381e503d7236b8ed6